### PR TITLE
feat: preserve mention ids in display textarea

### DIFF
--- a/src/components/DisplayMentionsTextarea.jsx
+++ b/src/components/DisplayMentionsTextarea.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { useMention } from '../contexts/MentionContext';
 import MentionsTextarea from './MentionsTextarea';
 
@@ -30,21 +30,60 @@ const DisplayMentionsTextarea = ({
   style,
   ...props
 }) => {
-  const { renderWithMentions } = useMention();
-  
+  const { users } = useMention();
+
+  // Maintain the raw value with @[username](userId) tokens
+  const [rawValue, setRawValue] = useState(value || '');
+
+  // Keep rawValue in sync with external value changes
+  useEffect(() => {
+    setRawValue(value || '');
+  }, [value]);
+
+  // Map of display names to user IDs for reconstructing raw value
+  const nameIdMap = useMemo(() => {
+    const map = {};
+    users.forEach((user) => {
+      const displayName = user.nickname || user.full_name;
+      if (displayName) {
+        map[displayName] = user.id;
+      }
+    });
+    return map;
+  }, [users]);
+
   // Transform the display value (what the user sees)
   // This ensures the user sees @username instead of @[username](userId)
-  const displayValue = value ? value.replace(/@\[([^\]]+)\]\(([^)]+)\)/g, '@$1') : '';
-  
+  const displayValue = rawValue
+    ? rawValue.replace(/@\[([^\]]+)\]\(([^)]+)\)/g, '@$1')
+    : '';
+
   // Handle changes in the textarea
   const handleChange = (e) => {
-    // When user types, we need to pass the event to the parent component
-    onChange(e);
+    const inputValue = e.target.value;
+
+    // Convert display mentions back to raw format using the name → ID map
+    const newRawValue = inputValue.replace(/@([\w.-]+)/g, (match, name) => {
+      const id = nameIdMap[name];
+      return id ? `@[${name}](${id})` : match;
+    });
+
+    setRawValue(newRawValue);
+
+    // Pass the reconstructed raw value to the parent
+    if (onChange) {
+      const syntheticEvent = {
+        ...e,
+        target: { ...e.target, value: newRawValue }
+      };
+      onChange(syntheticEvent);
+    }
   };
 
   return (
     <MentionsTextarea
       value={displayValue}
+      rawValue={rawValue}
       onChange={handleChange}
       placeholder={placeholder}
       disabled={disabled}


### PR DESCRIPTION
## Summary
- maintain raw `@[username](id)` value in DisplayMentionsTextarea
- reconstruct raw tokens from display text using a user name→id map
- forward raw value to parent and pass it to wrapped MentionsTextarea

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68963644340483298d32162889ceb8c2