### PR TITLE
fix: enable mentions in general talk comments

### DIFF
--- a/src/components/DisplayMentionsTextarea.jsx
+++ b/src/components/DisplayMentionsTextarea.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useMention } from '../contexts/MentionContext';
 import MentionsTextarea from './MentionsTextarea';
 
 /**
@@ -30,16 +29,33 @@ const DisplayMentionsTextarea = ({
   style,
   ...props
 }) => {
-  const { renderWithMentions } = useMention();
-  
   // Transform the display value (what the user sees)
   // This ensures the user sees @username instead of @[username](userId)
   const displayValue = value ? value.replace(/@\[([^\]]+)\]\(([^)]+)\)/g, '@$1') : '';
-  
+
   // Handle changes in the textarea
   const handleChange = (e) => {
-    // When user types, we need to pass the event to the parent component
-    onChange(e);
+    const inputValue = e.target.value;
+
+    // Build a map of existing mentions from the original value
+    const mentionRegex = /@\[([^\]]+)\]\(([^)]+)\)/g;
+    const mentionMap = {};
+    let match;
+    while ((match = mentionRegex.exec(value || '')) !== null) {
+      mentionMap[`@${match[1]}`] = match[0];
+    }
+
+    // Replace display mentions with their full markup counterparts
+    let newValue = inputValue;
+    Object.entries(mentionMap).forEach(([display, markup]) => {
+      newValue = newValue.split(display).join(markup);
+    });
+
+    const syntheticEvent = {
+      ...e,
+      target: { ...e.target, value: newValue }
+    };
+    onChange(syntheticEvent);
   };
 
   return (

--- a/src/components/GeneralTalk.jsx
+++ b/src/components/GeneralTalk.jsx
@@ -409,8 +409,8 @@ const GeneralTalk = () => {
 
       if (error) throw error;
 
-      // Process mentions in the comment
-      processMentions(text.trim(), 'general_topic_comment', topicId);
+      // Process mentions in the comment using the comment ID
+      processMentions(text.trim(), 'general_topic_comment', data[0].id);
 
       // Enhance the comment with user data
       const { data: userData, error: userError } = await supabase.


### PR DESCRIPTION
## Summary
- preserve mention markup when editing text with DisplayMentionsTextarea
- record mentions on General Talk comments using the new comment ID

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68970fc42f508329bcdba4d193b526f5